### PR TITLE
pybind example

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+pybind11

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,26 @@
 from setuptools import setup, find_packages
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
+__version__ = "0.0.1"
+ext_modules = [
+    Pybind11Extension("lhapdfwrap",
+        ["src/main.cpp"],
+        # Example: passing in the version to the compiled code
+        define_macros = [('VERSION_INFO', __version__)],
+        ),
+]
+
 setup(
     name = 'package',
-    version = '0.0.1',
+    version=__version__,
     url = 'https://github.com/LHC-DMWG/DMWG-couplingScan-code/',
     author = 'LHC DMWG',
     author_email = 'lhc-dmwg-contributors-couplingscan@cern.ch',
     description = '',
     packages = find_packages(),    
     install_requires = requirements,
+    ext_modules=ext_modules
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,38 @@
+#include <pybind11/pybind11.h>
+
+#define STRINGIFY(x) #x
+#define MACRO_STRINGIFY(x) STRINGIFY(x)
+
+int add(int i, int j) {
+    return i + j;
+}
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(lhapdfwrap, m) {
+    m.doc() = R"pbdoc(
+        Pybind11 example plugin
+        -----------------------
+        .. currentmodule:: lhapdfwrap
+        .. autosummary::
+           :toctree: _generate
+           add
+           subtract
+    )pbdoc";
+
+    m.def("add", &add, R"pbdoc(
+        Add two numbers
+        Some other explanation about the add function.
+    )pbdoc");
+
+    m.def("subtract", [](int i, int j) { return i - j; }, R"pbdoc(
+        Subtract two numbers
+        Some other explanation about the subtract function.
+    )pbdoc");
+
+#ifdef VERSION_INFO
+    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+#else
+    m.attr("__version__") = "dev";
+#endif
+}


### PR DESCRIPTION
Example implementation for shipping integrated cpp code. Example stolen straight from [the pybind example](https://github.com/pybind/python_example).

To get more complicated functions, we can expand `src/main.cpp` / add more files, etc.

Currently, you can just:

```
cd DMWG-couplingScan-code
pip install -e .
```

and then in python:

```
import lhapdfwrap
lhapdfwrap.add(1,2) # dummy function
```